### PR TITLE
Fixed recalculating measurements for family module

### DIFF
--- a/src/Measurements/ActivePaidAccessesMeasurement.php
+++ b/src/Measurements/ActivePaidAccessesMeasurement.php
@@ -45,8 +45,8 @@ class ActivePaidAccessesMeasurement extends BaseMeasurement
                 'start_time <' => $next,
                 'end_time >=' => $date,
                 'users.active' => 1,
-                'subscription_type_id NOT' => $this->db()::literal(
-                    'IN (SELECT master_subscription_type_id FROM family_subscription_types)'
+                'subscription_type_id NOT IN' => $this->db()::literal(
+                    '(SELECT master_subscription_type_id FROM family_subscription_types)'
                 ),
             ],
         );


### PR DESCRIPTION
Hi, reporting possible bug issue.

Based on the checking of the server error logs of the client, there is a DB typo in recalculating a subscription statistics when in family module subscriptions context. 

This bug has been occuring from 3.7 (maybe also 3.6 not sure now). Haven't checked the 4.0 version yet.

**The stack trace:**
`PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IN (SELECT master_subscription_type_id FROM family_subscription_types)))
       ' at line 4 in /var/www/html/vendor/nette/database/src/Database/ResultSet.php:56`

**The command:**
`php bin/command.php application:calculate-measurements --daily`


Thank you. 